### PR TITLE
ffe.routing/main.yml: Fix typo for bird6 notify handler

### DIFF
--- a/roles/ffe.routing/tasks/main.yml
+++ b/roles/ffe.routing/tasks/main.yml
@@ -23,7 +23,7 @@
 - template: src=bgp.conf.j2 dest={{bird_config_dir}}/bgp.conf owner=bird mode=0600
   notify: 
     - Reload bird
-    - Relaod bird6
+    - Reload bird6
 
 - template: src=bird.d/upstream.conf.j2 dest={{bird_config_dir}}/bird.d/upstream.conf owner=bird mode=0600
   notify: Reload bird


### PR DESCRIPTION
There is a typo in your main.yml to the bird6 reload notify handler, so this will most likely not work. this MR fixes the typo, nothing more ;)